### PR TITLE
Log download manifest.url when starting download

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -245,7 +245,7 @@ class DownloadManager {
               manifest.retryLimit ?? this.defaultRetryLimit
             } with delay ${delayInSeconds} seconds`
           : ""
-      }`
+      } from ${manifest.url}`
     );
     try {
       const file = await this.start(


### PR DESCRIPTION
We need better logging in DownloadManager if we are to quickly track down problems with asset/game downloads